### PR TITLE
タスク詳細取得機能の追加

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -184,6 +184,9 @@ paths:
                     tittle: コーヒー豆を買う
                     body: いつものコーヒーショップでブレンドを100g
                     priority: 1
+                    user: 4daf76eb-fb5a-4bf0-8053-40f5e6bdd8e8
+                    updatedAt: "2021-11-02T12:42:33.087Z"
+                    createdAt: "2021-11-02T12:42:33.087Z"
         "401":
           description: Unauthorized
         "404":

--- a/lib/my-todo-list-stack.ts
+++ b/lib/my-todo-list-stack.ts
@@ -104,6 +104,11 @@ export class MyTodoListStack extends cdk.Stack {
       path: '/tasks',
       integration: new LambdaProxyIntegration({ handler: handler }),
     });
+    httpApi.addRoutes({
+      methods: [apigw.HttpMethod.GET],
+      path: '/tasks/{id}',
+      integration: new LambdaProxyIntegration({ handler: handler }),
+    });
 
     // Cfn Output
     new cdk.CfnOutput(this, 'userPoolId', { value: userPool.userPoolId });

--- a/src/domains/app.ts
+++ b/src/domains/app.ts
@@ -11,6 +11,7 @@ app.use(morgan('combined'));
 
 app.get('/', tuc.healthCheck);
 
+app.get('/tasks/:id', tuc.getTask);
 app.post('/tasks', createTaskValidator, tuc.createTask);
 
 // error handler

--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -36,3 +36,21 @@ export const createTask = async (
     next(err);
   }
 };
+
+export const getTask = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const token = req.headers['authorization'];
+  const user: string = jwtDecode<JwtPayload>(token!).sub!;
+  try {
+    const result: Task = await ddb.getTask(user, req.params.id);
+    console.log(result);
+    result
+      ? res.json(result)
+      : res.status(404).json('Sorry cant find the task!');
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -46,7 +46,6 @@ export const getTask = async (
   const user: string = jwtDecode<JwtPayload>(token!).sub!;
   try {
     const result: Task = await ddb.getTask(user, req.params.id);
-    console.log(result);
     result
       ? res.json(result)
       : res.status(404).json('Sorry cant find the task!');

--- a/src/infrastructures/dynamodb/tasks-table.ts
+++ b/src/infrastructures/dynamodb/tasks-table.ts
@@ -23,3 +23,17 @@ export const createTask = async (taskInfo: Task): Promise<Task> => {
   );
   return taskInfo;
 };
+
+export const getTask = async (user: string, taskId: string): Promise<Task> => {
+  const params: ddbLib.GetCommandInput = {
+    TableName: tableName,
+    Key: {
+      user: user,
+      id: taskId,
+    },
+  };
+  const data: ddbLib.GetCommandOutput = await ddbDocClient.send(
+    new ddbLib.GetCommand(params)
+  );
+  return data.Item as Task;
+};

--- a/test/domains/tasks-use-case.test.ts
+++ b/test/domains/tasks-use-case.test.ts
@@ -62,4 +62,33 @@ describe('ユースケース', () => {
     expect(res.status).toEqual(201);
     expect(res.body).toEqual(expectedItem);
   });
+
+  test('タスク詳細の取得ができること', async () => {
+    const token = cognitoJwtGenerator('test-user');
+    const inputId: string = '4e469469-2745-4f9d-a7b4-f59b67b54bee';
+    const user: string = '7d8ca528-4931-4254-9273-ea5ee853f271';
+
+    const expectedItem: Task = {
+      tittle: 'コーヒー豆を買う',
+      body: 'いつものコーヒーショップでブレンドを100g',
+      priority: 1,
+      user: '7d8ca528-4931-4254-9273-ea5ee853f271',
+      createdAt: '2021-11-01T12:31:18.023Z',
+      updatedAt: '2021-11-01T12:31:18.023Z',
+      id: '4e469469-2745-4f9d-a7b4-f59b67b54bee',
+      completed: false,
+    };
+    const getTaskMock = (infra.getTask as jest.Mock).mockResolvedValue(
+      expectedItem
+    );
+    const res: request.Response = await request(server)
+      .get(`/tasks/${inputId}`)
+      .set('authorization', token)
+      .send();
+    expect(getTaskMock.mock.calls.length).toBe(1);
+    expect(getTaskMock.mock.calls[0][0]).toEqual(user); // userの確認
+    expect(getTaskMock.mock.calls[0][1]).toEqual(inputId); // idの確認
+    expect(res.status).toEqual(200);
+    expect(res.body).toEqual(expectedItem);
+  });
 });

--- a/test/infrastructures/dynamodb/tasks-table.test.ts
+++ b/test/infrastructures/dynamodb/tasks-table.test.ts
@@ -40,4 +40,29 @@ describe('インフラ', () => {
     const res: Task = await infra.createTask(inputItem);
     expect(res).toStrictEqual(inputItem);
   });
+
+  test('タスクの詳細が取得ができること', async () => {
+    const inputId = '4e469469-2745-4f9d-a7b4-f59b67b54bee';
+    const user = '7d8ca528-4931-4254-9273-ea5ee853f271';
+    const expectedItem: Task = {
+      tittle: 'コーヒー豆を買う',
+      body: 'いつものコーヒーショップでブレンドを100g',
+      priority: 1,
+      user: '7d8ca528-4931-4254-9273-ea5ee853f271',
+      createdAt: '2021-11-01T12:31:18.023Z',
+      updatedAt: '2021-11-01T12:31:18.023Z',
+      id: '4e469469-2745-4f9d-a7b4-f59b67b54bee',
+      completed: false,
+    };
+    ddbMock
+      .on(ddbLib.GetCommand, {
+        TableName: tableName,
+        Key: { id: inputId },
+      })
+      .resolves({
+        Item: expectedItem,
+      });
+    const res: Task = await infra.getTask(user, inputId);
+    expect(res).toStrictEqual(expectedItem);
+  });
 });


### PR DESCRIPTION
## チケットへのリンク

* close #17 

## やったこと

* 認証されたユーザーは自分の既存タスクの詳細を見ることができる機能の実装
    * `user`と`id`を元にDynamoDBからタスクを取得 
* ロジックのテストコードの実装 
* Swaggerのアップデート

## やらないこと

* インフラ（CDK）のテストコードの実装

## できるようになること（ユーザ目線）

* 認証されたユーザーは自分の既存タスクの詳細を見ることができる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] ローカルでテストコードが通ることを確認
* 開発環境にデプロイしてPostmanから以下を確認
    * [x] タスク詳細の取得成功時にAPIがステータスコード`200`を返すこと
        * [x] 取得したタスクがDynamo DBに登録されている内容と一致していること（マネジメントコンソールから確認）
    * [x] 対応するタスクが存在しない場合、ステータスコード`400`を返すこと
    * [x] 認証されていないユーザーにステータスコード`401`を返すこと

## その他

* なし