### PR TITLE
タスク一覧取得機能の追加

### DIFF
--- a/src/domains/app.ts
+++ b/src/domains/app.ts
@@ -11,8 +11,10 @@ app.use(morgan('combined'));
 
 app.get('/', tuc.healthCheck);
 
-app.get('/tasks/:id', tuc.getTask);
+app.get('/tasks', tuc.getTasks);
 app.post('/tasks', createTaskValidator, tuc.createTask);
+
+app.get('/tasks/:id', tuc.getTask);
 
 // error handler
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {

--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -2,7 +2,7 @@ import jwtDecode, { JwtPayload } from 'jwt-decode';
 
 import { Express, Request, Response, NextFunction } from 'express';
 import * as ddb from '../infrastructures/dynamodb/tasks-table';
-import { Task } from '../utils/types';
+import { Task, TaskSummary } from '../utils/types';
 import { validationResult } from 'express-validator';
 
 export const healthCheck = (req: Request, res: Response): void => {
@@ -49,6 +49,21 @@ export const getTask = async (
     result
       ? res.json(result)
       : res.status(404).json('Sorry cant find the task!');
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getTasks = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const token = req.headers['authorization'];
+  const user: string = jwtDecode<JwtPayload>(token!).sub!;
+  try {
+    const result: TaskSummary[] = await ddb.getTasks(user);
+    res.json(result);
   } catch (err) {
     next(err);
   }

--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -9,6 +9,11 @@ export const healthCheck = (req: Request, res: Response): void => {
   res.json({ message: 'API is working!' });
 };
 
+const getUser = (req: Request): string => {
+  const token = req.headers['authorization'];
+  return jwtDecode<JwtPayload>(token!).sub!;
+};
+
 export const createTask = async (
   req: Request,
   res: Response,
@@ -20,10 +25,8 @@ export const createTask = async (
     res.status(400).json({ errors: errors.array() });
     return;
   }
-  const token = req.headers['authorization'];
-  const decoded = jwtDecode<JwtPayload>(token!);
   const taskInfo: Task = req.body;
-  taskInfo.user = decoded.sub;
+  taskInfo.user = getUser(req);
 
   const currentTime: string = new Date().toISOString();
   taskInfo.createdAt = currentTime;
@@ -42,8 +45,7 @@ export const getTask = async (
   res: Response,
   next: NextFunction
 ): Promise<void> => {
-  const token = req.headers['authorization'];
-  const user: string = jwtDecode<JwtPayload>(token!).sub!;
+  const user: string = getUser(req);
   try {
     const result: Task = await ddb.getTask(user, req.params.id);
     result
@@ -59,8 +61,7 @@ export const getTasks = async (
   res: Response,
   next: NextFunction
 ): Promise<void> => {
-  const token = req.headers['authorization'];
-  const user: string = jwtDecode<JwtPayload>(token!).sub!;
+  const user: string = getUser(req);
   try {
     const result: TaskSummary[] = await ddb.getTasks(user);
     res.json(result);

--- a/src/infrastructures/dynamodb/tasks-table.ts
+++ b/src/infrastructures/dynamodb/tasks-table.ts
@@ -1,7 +1,7 @@
 import * as ddbLib from '@aws-sdk/lib-dynamodb';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { v4 as uuidv4 } from 'uuid';
-import { Task } from '../../utils/types';
+import { Task, TaskSummary } from '../../utils/types';
 
 const tableName: string | undefined = process.env.TABLE_NAME;
 if (!tableName) {
@@ -24,7 +24,7 @@ export const createTask = async (taskInfo: Task): Promise<Task> => {
   return taskInfo;
 };
 
-export const getTask = async (user: string, taskId: string): Promise<Task> => {
+export const getTask = async (user: string, taskId?: string): Promise<Task> => {
   const params: ddbLib.GetCommandInput = {
     TableName: tableName,
     Key: {
@@ -36,4 +36,22 @@ export const getTask = async (user: string, taskId: string): Promise<Task> => {
     new ddbLib.GetCommand(params)
   );
   return data.Item as Task;
+};
+
+export const getTasks = async (user: string): Promise<TaskSummary[]> => {
+  const params: ddbLib.QueryCommandInput = {
+    TableName: tableName,
+    ExpressionAttributeNames: {
+      '#user': 'user',
+    },
+    ExpressionAttributeValues: {
+      ':u': user,
+    },
+    KeyConditionExpression: '#user = :u',
+    ProjectionExpression: 'id, tittle, priority, completed',
+  };
+  const data: ddbLib.QueryCommandOutput = await ddbDocClient.send(
+    new ddbLib.QueryCommand(params)
+  );
+  return data.Items as TaskSummary[];
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,3 +8,10 @@ export type Task = {
   createdAt: string;
   updatedAt: string;
 };
+
+export type TaskSummary = {
+  id: string;
+  tittle: string;
+  priority: number;
+  completed: boolean;
+};


### PR DESCRIPTION
## チケットへのリンク

* close #4 

## やったこと

* 認証されたユーザーは自分のタスクの一覧を見ることができる機能の実装
    * DynamoDBのクエリ（`projectionExpression`も利用）で実装
* ロジックのテストコードの実装 

## やらないこと

* インフラ（CDK）のテストコードの実装

## できるようになること（ユーザ目線）

* 認証されたユーザーは自分のタスクの一覧を見ることができる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] ローカルでテストコードが通ることを確認
* 開発環境にデプロイしてPostmanから以下を確認
    * [x] タスク一覧の取得成功時にAPIがステータスコード`200`を返すこと
        * [x] 取得したタスク一覧がDynamo DBに登録されている内容と一致していること（マネジメントコンソールから確認）
            * [x] ユーザーが異なるタスクの情報は取得できないこと（マネジメントコンソールから確認）
    * [x] 認証されていないユーザーにステータスコード`401`を返すこと

## その他

* なし