### PR TITLE
タスク更新機能の追加

### DIFF
--- a/lib/my-todo-list-stack.ts
+++ b/lib/my-todo-list-stack.ts
@@ -105,7 +105,7 @@ export class MyTodoListStack extends cdk.Stack {
       integration: new LambdaProxyIntegration({ handler: handler }),
     });
     httpApi.addRoutes({
-      methods: [apigw.HttpMethod.GET],
+      methods: [apigw.HttpMethod.GET, apigw.HttpMethod.PUT],
       path: '/tasks/{id}',
       integration: new LambdaProxyIntegration({ handler: handler }),
     });

--- a/src/domains/app.ts
+++ b/src/domains/app.ts
@@ -1,7 +1,7 @@
 import express = require('express');
 import { Express, Request, Response, NextFunction } from 'express';
 import * as tuc from './tasks-use-case';
-import { createTaskValidator } from './validators';
+import { createTaskValidator, updateTaskValidator } from './validators';
 
 const app: Express = express().disable('x-powered-by');
 const morgan = require('morgan');
@@ -15,6 +15,7 @@ app.get('/tasks', tuc.getTasks);
 app.post('/tasks', createTaskValidator, tuc.createTask);
 
 app.get('/tasks/:id', tuc.getTask);
+app.put('/tasks/:id', updateTaskValidator, tuc.updateTask);
 
 // error handler
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {

--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -16,7 +16,6 @@ const getUser = (req: Request): string => {
 
 const validation = (req: Request, res: Response): void => {
   const errors = validationResult(req);
-  console.log(errors);
   if (!errors.isEmpty()) {
     res.status(400).json({ errors: errors.array() });
     return;

--- a/src/domains/validators.ts
+++ b/src/domains/validators.ts
@@ -4,3 +4,9 @@ export const createTaskValidator = [
   check('tittle').isString().trim().notEmpty(),
   check('priority').isNumeric(),
 ];
+
+export const updateTaskValidator = [
+  body('tittle').exists().trim().notEmpty().isString(),
+  body('priority').exists().not().isString().isInt(),
+  body('completed').exists().notEmpty().isBoolean(),
+];

--- a/src/domains/validators.ts
+++ b/src/domains/validators.ts
@@ -1,8 +1,8 @@
-import { body, check } from 'express-validator';
+import { body } from 'express-validator';
 
 export const createTaskValidator = [
-  check('tittle').isString().trim().notEmpty(),
-  check('priority').isNumeric(),
+  body('tittle').exists().trim().notEmpty().isString(),
+  body('priority').exists().not().isString().isInt(),
 ];
 
 export const updateTaskValidator = [

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,5 @@
 export type Task = {
-  id: string;
+  id?: string;
   user?: string;
   completed: boolean;
   tittle: string;
@@ -14,4 +14,12 @@ export type TaskSummary = {
   tittle: string;
   priority: number;
   completed: boolean;
+};
+
+export type UpdateTaskInfo = {
+  tittle: string;
+  body: string;
+  priority: number;
+  completed: boolean;
+  updatedAt?: string;
 };

--- a/test/infrastructures/dynamodb/tasks-table.test.ts
+++ b/test/infrastructures/dynamodb/tasks-table.test.ts
@@ -100,4 +100,59 @@ describe('インフラ', () => {
     const res: Task = await infra.getTask(user, inputId);
     expect(res).toStrictEqual(expectedItem);
   });
+
+  test('IDに対応するタスクの更新ができること', async () => {
+    const inputId = '4e469469-2745-4f9d-a7b4-f59b67b54bee';
+    const user = '7d8ca528-4931-4254-9273-ea5ee853f271';
+    const inputItem = {
+      tittle: 'コーヒー豆を買う',
+      body: 'いつものコーヒーショップでブレンドを100g',
+      priority: 2,
+      user: '7d8ca528-4931-4254-9273-ea5ee853f271',
+      updatedAt: '2021-11-01T12:31:18.023Z',
+      id: '4e469469-2745-4f9d-a7b4-f59b67b54bee',
+      completed: true,
+    };
+    const expectedItem: Task = {
+      tittle: 'コーヒー豆を買う',
+      body: 'いつものコーヒーショップでブレンドを100g',
+      priority: 2,
+      user: '7d8ca528-4931-4254-9273-ea5ee853f271',
+      createdAt: '2021-11-01T12:31:18.023Z',
+      updatedAt: '2021-11-01T12:31:18.023Z',
+      id: '4e469469-2745-4f9d-a7b4-f59b67b54bee',
+      completed: true,
+    };
+    ddbMock
+      .on(ddbLib.UpdateCommand, {
+        TableName: tableName,
+        Key: { id: inputId, user: user },
+        UpdateExpression:
+          'set #att_tittle =:tittle,#att_body =:body,#att_priority =:priority,#att_user =:user,#att_updatedAt =:updatedAt,#att_id =:id,#att_completed =:completed',
+        ExpressionAttributeNames: {
+          '#att_tittle': 'tittle',
+          '#att_body': 'body',
+          '#att_priority': 'priority',
+          '#att_user': 'user',
+          '#att_updatedAt': 'updatedAt',
+          '#att_id': 'id',
+          '#att_completed': 'completed',
+        },
+        ExpressionAttributeValues: {
+          ':tittle': 'コーヒー豆を買う',
+          ':body': 'いつものコーヒーショップでブレンドを100g',
+          ':priority': 2,
+          ':user': user,
+          ':updatedAt': '2021-11-01T12:31:18.023Z',
+          ':id': inputId,
+          ':completed': true,
+        },
+        ReturnValues: 'ALL_NEW',
+      })
+      .resolves({
+        Attributes: expectedItem,
+      });
+    const res: Task = await infra.updateTask(user, inputId, inputItem);
+    expect(res).toStrictEqual(expectedItem);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2018",
     "module": "commonjs",
     "lib": [
-      "es2018"
+      "es2019"
     ],
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
## チケットへのリンク

* close #3 

## やったこと

* 認証されたユーザーは自分のタスクを更新できる機能の実装
    *  DynamoDBの更新系で実装
    * リクエストボディのバリデーションの実装
       * 登録系のバリデーションも合わせてアップデート 
    * ロジックのテストコードの実装

## やらないこと

* インフラ（CDK）のテストコードの実装

## できるようになること（ユーザ目線）

* 認証されたユーザーは自分のタスクの更新

## できなくなること（ユーザ目線）

* タスクに対して`tittle`, `body`, `priority`, `completed` 以外の項目の（更新系による）登録
    *  リクエストボディに含まれていても内部的に破棄される

## 動作確認

* [x] ローカルでテストコードが通ることを確認
* 開発環境にデプロイしてPostmanから以下を確認
    * [x] タスク一覧の更新成功時にAPIがステータスコード`200`を返すこと
        * [x] 返されるタスク情報がDynamoDBに登録されている内容と一致していること（マネジメントコンソールから確認）
    * [x] バリデーションエラー時にステータスコード`400`を返すこと
    * [x] 認証されていないユーザーにステータスコード`401`を返すこと

## その他

* なし