### PR TITLE
タスク削除機能の追加

### DIFF
--- a/lib/my-todo-list-stack.ts
+++ b/lib/my-todo-list-stack.ts
@@ -105,7 +105,11 @@ export class MyTodoListStack extends cdk.Stack {
       integration: new LambdaProxyIntegration({ handler: handler }),
     });
     httpApi.addRoutes({
-      methods: [apigw.HttpMethod.GET, apigw.HttpMethod.PUT],
+      methods: [
+        apigw.HttpMethod.GET,
+        apigw.HttpMethod.PUT,
+        apigw.HttpMethod.DELETE,
+      ],
       path: '/tasks/{id}',
       integration: new LambdaProxyIntegration({ handler: handler }),
     });

--- a/src/domains/app.ts
+++ b/src/domains/app.ts
@@ -16,6 +16,7 @@ app.post('/tasks', createTaskValidator, tuc.createTask);
 
 app.get('/tasks/:id', tuc.getTask);
 app.put('/tasks/:id', updateTaskValidator, tuc.updateTask);
+app.delete('/tasks/:id', tuc.deleteTask);
 
 // error handler
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {

--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -112,3 +112,19 @@ export const updateTask = async (
     next(err);
   }
 };
+
+export const deleteTask = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const user = getUser(req);
+  try {
+    const result = await ddb.deleteTask(user, req.params.id);
+    result
+      ? res.status(204).json('{}')
+      : res.status(404).json('Sorry cant find the task!');
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/infrastructures/dynamodb/tasks-table.ts
+++ b/src/infrastructures/dynamodb/tasks-table.ts
@@ -88,3 +88,18 @@ export const updateTask = async (
   );
   return result.Attributes as Task;
 };
+
+export const deleteTask = async (user: string, id: string) => {
+  const params: ddbLib.DeleteCommandInput = {
+    TableName: tableName,
+    Key: {
+      id: id,
+      user: user,
+    },
+    ReturnValues: 'ALL_OLD',
+  };
+  const result: ddbLib.DeleteCommandOutput = await ddbDocClient.send(
+    new ddbLib.DeleteCommand(params)
+  );
+  return result.Attributes;
+};

--- a/test/domains/tasks-use-case.test.ts
+++ b/test/domains/tasks-use-case.test.ts
@@ -153,4 +153,27 @@ describe('ユースケース', () => {
     expect(res.status).toEqual(200);
     expect(res.body).toEqual(expectedItem);
   });
+
+  test('タスクの削除ができること', async () => {
+    const token = cognitoJwtGenerator('test-user');
+    const inputId: string = '4e469469-2745-4f9d-a7b4-f59b67b54bee';
+    const user: string = '7d8ca528-4931-4254-9273-ea5ee853f271';
+
+    const expectedItem = {
+      id: inputId,
+      user: user,
+    };
+    const deleteTaskMock = (infra.deleteTask as jest.Mock).mockResolvedValue(
+      expectedItem
+    );
+    const res: request.Response = await request(server)
+      .delete(`/tasks/${inputId}`)
+      .set('authorization', token)
+      .send();
+    expect(deleteTaskMock.mock.calls.length).toBe(1);
+    expect(deleteTaskMock.mock.calls[0][0]).toEqual(user);
+    expect(deleteTaskMock.mock.calls[0][1]).toEqual(inputId);
+    expect(res.status).toEqual(204);
+    expect(res.body).toEqual({});
+  });
 });

--- a/test/infrastructures/dynamodb/tasks-table.test.ts
+++ b/test/infrastructures/dynamodb/tasks-table.test.ts
@@ -156,7 +156,7 @@ describe('インフラ', () => {
     expect(res).toStrictEqual(expectedItem);
   });
 
-  test('IDに対応するクマ情報の削除ができること', async () => {
+  test('IDに対応するタスクの削除ができること', async () => {
     const inputId = '4e469469-2745-4f9d-a7b4-f59b67b54bee';
     const user = '7d8ca528-4931-4254-9273-ea5ee853f271';
     const expectedItem: Task = {

--- a/test/infrastructures/dynamodb/tasks-table.test.ts
+++ b/test/infrastructures/dynamodb/tasks-table.test.ts
@@ -155,4 +155,33 @@ describe('インフラ', () => {
     const res: Task = await infra.updateTask(user, inputId, inputItem);
     expect(res).toStrictEqual(expectedItem);
   });
+
+  test('IDに対応するクマ情報の削除ができること', async () => {
+    const inputId = '4e469469-2745-4f9d-a7b4-f59b67b54bee';
+    const user = '7d8ca528-4931-4254-9273-ea5ee853f271';
+    const expectedItem: Task = {
+      tittle: 'コーヒー豆を買う',
+      body: 'いつものコーヒーショップでブレンドを100g',
+      priority: 2,
+      user: '7d8ca528-4931-4254-9273-ea5ee853f271',
+      createdAt: '2021-11-01T12:31:18.023Z',
+      updatedAt: '2021-11-01T12:31:18.023Z',
+      id: '4e469469-2745-4f9d-a7b4-f59b67b54bee',
+      completed: true,
+    };
+    ddbMock
+      .on(ddbLib.DeleteCommand, {
+        TableName: tableName,
+        Key: {
+          id: inputId,
+          user: user,
+        },
+        ReturnValues: 'ALL_OLD',
+      })
+      .resolves({
+        Attributes: expectedItem,
+      });
+    const res = await infra.deleteTask(user, inputId);
+    expect(res).toStrictEqual(expectedItem);
+  });
 });


### PR DESCRIPTION
## チケットへのリンク

* close #1

## やったこと

* 認証されたユーザーは自分のタスクを削除できる機能の実装
    *  DynamoDBの削除系で実装
    * ロジックのテストコードの実装

## やらないこと

* インフラ（CDK）のテストコードの実装

## できるようになること（ユーザ目線）

* 認証されたユーザーは自分のタスクを削除できる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] ローカルでテストコードが通ることを確認
* 開発環境にデプロイしてPostmanから以下を確認
    * [x] タスク削除成功時にAPIがステータスコード`204`を返すこと
        * [x] 対象のタスクがDynamoDBから削除されていること（マネジメントコンソールから確認）
    * [x] タスクが見つからない場合はエラーメッセージとともにステータスコード`404`を返すこと 
    * [x] 認証されていないユーザーにステータスコード`401`を返すこと

## その他

* なし