### PR TITLE
タスク登録機能のバグの修正

### DIFF
--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -31,6 +31,8 @@ export const createTask = async (
   const taskInfo: Task = req.body;
   taskInfo.user = getUser(req);
 
+  taskInfo.completed = false;
+
   const currentTime: string = new Date().toISOString();
   taskInfo.createdAt = currentTime;
   taskInfo.updatedAt = currentTime;

--- a/test/domains/tasks-use-case.test.ts
+++ b/test/domains/tasks-use-case.test.ts
@@ -42,12 +42,12 @@ describe('ユースケース', () => {
       body: 'いつものコーヒーショップでブレンドを100g',
       priority: 1,
       user: jwtDecode<JwtPayload>(token!).sub,
+      completed: false,
       createdAt: expect.anything(), // モックを叩く際にcreatedAt, updatedAtが自動生成されるためanythingを利用
       updatedAt: expect.anything(),
     };
     const expectedItem: Task = {
       id: uuidv4(),
-      completed: false,
       ...inputItem,
     };
     const createTaskMock = (infra.createTask as jest.Mock).mockResolvedValue(


### PR DESCRIPTION
## チケットへのリンク

* なし

## やったこと

* タスク登録時`completed`が含まれないまま登録されてしまうバグを修正
    * デフォルトで`"completed": false`を付与するように変更 

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] ローカルテストの実行 
* [x] デプロイしてPostmanから該当機能の修正を確認

## その他

* なし