### PR TITLE
Fix/update task

### DIFF
--- a/src/infrastructures/dynamodb/tasks-table.ts
+++ b/src/infrastructures/dynamodb/tasks-table.ts
@@ -24,7 +24,10 @@ export const createTask = async (taskInfo: Task): Promise<Task> => {
   return taskInfo;
 };
 
-export const getTask = async (user: string, taskId?: string): Promise<Task> => {
+export const getTask = async (
+  user: string,
+  taskId?: string
+): Promise<Task | undefined> => {
   const params: ddbLib.GetCommandInput = {
     TableName: tableName,
     Key: {
@@ -35,7 +38,11 @@ export const getTask = async (user: string, taskId?: string): Promise<Task> => {
   const data: ddbLib.GetCommandOutput = await ddbDocClient.send(
     new ddbLib.GetCommand(params)
   );
-  return data.Item as Task;
+  if (!data.Item) {
+    return undefined;
+  } else {
+    return data.Item as Task;
+  }
 };
 
 export const getTasks = async (user: string): Promise<TaskSummary[]> => {

--- a/test/infrastructures/dynamodb/tasks-table.test.ts
+++ b/test/infrastructures/dynamodb/tasks-table.test.ts
@@ -97,7 +97,7 @@ describe('インフラ', () => {
       .resolves({
         Item: expectedItem,
       });
-    const res: Task = await infra.getTask(user, inputId);
+    const res = await infra.getTask(user, inputId);
     expect(res).toStrictEqual(expectedItem);
   });
 


### PR DESCRIPTION
## チケットへのリンク

* close #23

## やったこと

* タスク更新時、対象となるタスクがDBに存在するかを確認するロジックを追加
    * 存在しない場合は`404`を返し、更新処理を中断させる

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* 登録済みでないタスクのアップデート（更新機能経由でのタスク登録）

## 動作確認

* [x] ローカルテストの実行 
* [x] デプロイしてPostmanから該当機能の修正を確認

## その他

* なし