### PR TITLE
タスク一覧取得時に優先度の若い順にソートされた結果を返すように修正

### DIFF
--- a/src/domains/tasks-use-case.ts
+++ b/src/domains/tasks-use-case.ts
@@ -69,6 +69,10 @@ export const getTasks = async (
   const user: string = getUser(req);
   try {
     const result: TaskSummary[] = await ddb.getTasks(user);
+    // 優先度が若い順にソート
+    result.sort((a, b) =>
+      a.priority < b.priority ? -1 : a.priority > b.priority ? 1 : 0
+    );
     res.json(result);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## チケットへのリンク

* close #29

## やったこと

* タスク一覧を取得した際に優先度が若い順にソートされた結果を返すように修正
    * ドメイン層でタスクの配列を`priority`でソート
        * 優先度は負の値でもゼロでもOK（これはこれで別途バリデーションする必要あり？）

## やらないこと

* なし

## できるようになること（ユーザ目線）

* タスク一覧を取得した際に優先度が若い順にソートされた結果を得られる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] ローカルテストの実行 
* [x] デプロイしてPostmanから該当機能の修正を確認

## その他

* なし