### PR TITLE
Web上でSwagger UIを利用できる機能の実装

### DIFF
--- a/bin/my-todo-list.ts
+++ b/bin/my-todo-list.ts
@@ -10,16 +10,16 @@ const resourceName = new ResourceName('MyTodoList', systemEnv);
 const app = new cdk.App();
 new MyTodoListStack(app, resourceName, {
   callbackUrls: [
-    // 'http://localhost:3200/oauth2-redirect.html',
+    'http://localhost:3200/oauth2-redirect.html',
     'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
   ],
   logoutUrls: [
-    // 'http://localhost:3200/oauth2-redirect.html',
+    'http://localhost:3200/oauth2-redirect.html',
     'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
   ],
   frontendUrls: [
-    // 'http://localhost:3200',
-    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/',
+    'http://localhost:3200',
+    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com',
   ],
   domainPrefix: process.env.DOMAIN_PREFIX!,
 });

--- a/bin/my-todo-list.ts
+++ b/bin/my-todo-list.ts
@@ -11,15 +11,15 @@ const app = new cdk.App();
 new MyTodoListStack(app, resourceName, {
   callbackUrls: [
     'http://localhost:3200/oauth2-redirect.html',
-    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
+    'https://main.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
   ],
   logoutUrls: [
     'http://localhost:3200/oauth2-redirect.html',
-    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
+    'https://main.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
   ],
   frontendUrls: [
     'http://localhost:3200',
-    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com',
+    'https://main.d68k7gpg5sbd1.amplifyapp.com',
   ],
   domainPrefix: process.env.DOMAIN_PREFIX!,
 });

--- a/bin/my-todo-list.ts
+++ b/bin/my-todo-list.ts
@@ -9,8 +9,17 @@ const resourceName = new ResourceName('MyTodoList', systemEnv);
 
 const app = new cdk.App();
 new MyTodoListStack(app, resourceName, {
-  callbackUrls: ['http://localhost:3200/oauth2-redirect.html'],
-  logoutUrls: ['http://localhost:3200/oauth2-redirect.html'],
-  frontendUrls: ['http://localhost:3200'],
+  callbackUrls: [
+    // 'http://localhost:3200/oauth2-redirect.html',
+    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
+  ],
+  logoutUrls: [
+    // 'http://localhost:3200/oauth2-redirect.html',
+    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/oauth2-redirect.html',
+  ],
+  frontendUrls: [
+    // 'http://localhost:3200',
+    'https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/',
+  ],
   domainPrefix: process.env.DOMAIN_PREFIX!,
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,53 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Swagger UI</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"
+    />
+    <style>
+      html {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.onload = function () {
+        // Build a system
+        const ui = SwaggerUIBundle({
+          url: './openapi.yaml',
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: 'StandaloneLayout',
+        });
+
+        window.ui = ui;
+      };
+    </script>
+  </body>
+</html>

--- a/docs/oauth2-redirect.html
+++ b/docs/oauth2-redirect.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Swagger UI: OAuth2 Redirect</title>
+  </head>
+  <body>
+    <script>
+      'use strict';
+      function run() {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+          qp = window.location.hash.substring(1);
+        } else {
+          qp = location.search.substring(1);
+        }
+
+        arr = qp.split('&');
+        arr.forEach(function (v, i, _arr) {
+          _arr[i] = '"' + v.replace('=', '":"') + '"';
+        });
+        qp = qp
+          ? JSON.parse('{' + arr.join() + '}', function (key, value) {
+              return key === '' ? value : decodeURIComponent(value);
+            })
+          : {};
+
+        isValid = qp.state === sentState;
+
+        if (
+          (oauth2.auth.schema.get('flow') === 'accessCode' ||
+            oauth2.auth.schema.get('flow') === 'authorizationCode' ||
+            oauth2.auth.schema.get('flow') === 'authorization_code') &&
+          !oauth2.auth.code
+        ) {
+          if (!isValid) {
+            oauth2.errCb({
+              authId: oauth2.auth.name,
+              source: 'auth',
+              level: 'warning',
+              message:
+                "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server",
+            });
+          }
+
+          if (qp.code) {
+            delete oauth2.state;
+            oauth2.auth.code = qp.code;
+            oauth2.callback({ auth: oauth2.auth, redirectUrl: redirectUrl });
+          } else {
+            let oauthErrorMsg;
+            if (qp.error) {
+              oauthErrorMsg =
+                '[' +
+                qp.error +
+                ']: ' +
+                (qp.error_description
+                  ? qp.error_description + '. '
+                  : 'no accessCode received from the server. ') +
+                (qp.error_uri ? 'More info: ' + qp.error_uri : '');
+            }
+
+            oauth2.errCb({
+              authId: oauth2.auth.name,
+              source: 'auth',
+              level: 'error',
+              message:
+                oauthErrorMsg ||
+                '[Authorization failed]: no accessCode received from the server',
+            });
+          }
+        } else {
+          oauth2.callback({
+            auth: oauth2.auth,
+            token: qp,
+            isValid: isValid,
+            redirectUrl: redirectUrl,
+          });
+        }
+        window.close();
+      }
+
+      window.addEventListener('DOMContentLoaded', function () {
+        run();
+      });
+    </script>
+  </body>
+</html>

--- a/lib/my-todo-list-stack.ts
+++ b/lib/my-todo-list-stack.ts
@@ -96,7 +96,7 @@ export class MyTodoListStack extends cdk.Stack {
       corsPreflight: {
         allowOrigins: props.frontendUrls,
         allowMethods: [apigw.CorsHttpMethod.ANY],
-        allowHeaders: ['authorization'],
+        allowHeaders: ['authorization', 'content-type'],
       },
     });
     httpApi.addRoutes({


### PR DESCRIPTION
## チケットへのリンク

* #36 

## やったこと

* Amplify ConsoleでSwaggerをホスト
    * `docs`ディレクトリをルートとしてAmplify側でCI/CDパイプラインを構築
* 上記に伴うCORSの設定 (以前からのPOST, PUTの不具合も合わせて修正)

* 一時確認用（後ほど削除）
   *  https://feature-amplify-console-swagger.d68k7gpg5sbd1.amplifyapp.com/
* 今後利用するもの（本PRマージ後に生成）
   *  https://main.d68k7gpg5sbd1.amplifyapp.com/

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] Amplify ConsoleでホストされたSwaggerからAPIを呼び出し
* [ ] 動作確認後、CORSおよびCognitoのコールバック用のURLを今後利用するものに変更してあるので、マージ後にはもう一度動作確認が必要

## その他
* なし
