### PR TITLE
インフラパラメータの見直しとインフラテストの追加

### DIFF
--- a/lib/my-todo-list-stack.ts
+++ b/lib/my-todo-list-stack.ts
@@ -30,6 +30,7 @@ export class MyTodoListStack extends cdk.Stack {
       tableName: tableName,
       partitionKey: { name: 'user', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
     });
 
     // Lambda
@@ -56,7 +57,7 @@ export class MyTodoListStack extends cdk.Stack {
       autoVerify: { email: true },
       signInAliases: { email: true },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      removalPolicy: cdk.RemovalPolicy.SNAPSHOT,
     });
     userPool.addDomain('domain', {
       cognitoDomain: { domainPrefix: props.domainPrefix },
@@ -75,11 +76,11 @@ export class MyTodoListStack extends cdk.Stack {
         flows: { authorizationCodeGrant: true },
       },
       userPoolClientName: userPoolClientName,
-      // generateSecret: false,
-      // authFlows: {
-      //   adminUserPassword: true,
-      // },
-      // preventUserExistenceErrors: true,
+      generateSecret: false,
+      authFlows: {
+        adminUserPassword: true,
+      },
+      preventUserExistenceErrors: true,
     });
 
     // API Gateway

--- a/test/my-todo-list.test.ts
+++ b/test/my-todo-list.test.ts
@@ -7,8 +7,8 @@ import * as cdk from '@aws-cdk/core';
 import * as todoApi from '../lib/my-todo-list-stack';
 import { ResourceName } from '../lib/resourceName';
 
-const systemEnv = process.env.SYSTEM_ENV ? process.env.SYSTEM_ENV : 'dev';
-const resourceName = new ResourceName('todo', systemEnv);
+const systemEnv = 'dev';
+const resourceName = new ResourceName('MyTodoList', systemEnv);
 
 const app = new cdk.App();
 const stack = new todoApi.MyTodoListStack(app, resourceName, {
@@ -20,20 +20,141 @@ const stack = new todoApi.MyTodoListStack(app, resourceName, {
 
 test('API Gateway', () => {
   expectCDK(stack).to(countResources('AWS::ApiGatewayV2::Api', 1));
+  expectCDK(stack).to(
+    haveResource('AWS::ApiGatewayV2::Api', {
+      CorsConfiguration: {
+        AllowHeaders: ['authorization', 'content-type'],
+        AllowMethods: ['*'],
+        AllowOrigins: ['http://localhost:3200'],
+      },
+      Name: 'MyTodoList-dev-todo-api',
+      ProtocolType: 'HTTP',
+    })
+  );
 });
 
 test('Lambda', () => {
   expectCDK(stack).to(countResources('AWS::Lambda::Function', 1));
+  expectCDK(stack).to(
+    haveResource('AWS::Lambda::Function', {
+      FunctionName: 'MyTodoList-dev-todo-function',
+      Handler: 'index.handler',
+      Runtime: 'nodejs14.x',
+      Environment: {
+        Variables: {
+          TABLE_NAME: 'MyTodoList-dev-todo-table',
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+        },
+      },
+      Role: {
+        'Fn::GetAtt': ['MyTodoListdevtodofunctionServiceRole3EC171A7', 'Arn'],
+      },
+    })
+  );
 });
 
 test('IAM Role', () => {
   expectCDK(stack).to(countResources('AWS::IAM::Role', 1));
+  expectCDK(stack).to(
+    haveResource('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          {
+            Action: 'sts:AssumeRole',
+            Effect: 'Allow',
+            Principal: {
+              Service: 'lambda.amazonaws.com',
+            },
+          },
+        ],
+        Version: '2012-10-17',
+      },
+      ManagedPolicyArns: [
+        {
+          'Fn::Join': [
+            '',
+            [
+              'arn:',
+              {
+                Ref: 'AWS::Partition',
+              },
+              ':iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+            ],
+          ],
+        },
+      ],
+    })
+  );
 });
 
 test('DynamoDB', () => {
   expectCDK(stack).to(countResources('AWS::DynamoDB::Table', 1));
+  expectCDK(stack).to(
+    haveResource('AWS::DynamoDB::Table', {
+      KeySchema: [
+        {
+          AttributeName: 'user',
+          KeyType: 'HASH',
+        },
+        {
+          AttributeName: 'id',
+          KeyType: 'RANGE',
+        },
+      ],
+      AttributeDefinitions: [
+        {
+          AttributeName: 'user',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        },
+      ],
+      TableName: 'MyTodoList-dev-todo-table',
+    })
+  );
 });
 
 test('Cognito UserPool', () => {
   expectCDK(stack).to(countResources('AWS::Cognito::UserPool', 1));
+  expectCDK(stack).to(
+    haveResource('AWS::Cognito::UserPool', {
+      AccountRecoverySetting: {
+        RecoveryMechanisms: [
+          {
+            Name: 'verified_email',
+            Priority: 1,
+          },
+        ],
+      },
+      AdminCreateUserConfig: {
+        AllowAdminCreateUserOnly: false,
+      },
+      AutoVerifiedAttributes: ['email'],
+      EmailVerificationMessage:
+        'The verification code to your new account is {####}',
+      EmailVerificationSubject: 'Verify your new account',
+      Schema: [
+        {
+          Mutable: true,
+          Name: 'email',
+          Required: true,
+        },
+      ],
+      SmsVerificationMessage:
+        'The verification code to your new account is {####}',
+      UsernameAttributes: ['email'],
+      UsernameConfiguration: {
+        CaseSensitive: false,
+      },
+      UserPoolName: 'MyTodoList-dev-todo-user-pool',
+      VerificationMessageTemplate: {
+        DefaultEmailOption: 'CONFIRM_WITH_CODE',
+        EmailMessage: 'The verification code to your new account is {####}',
+        EmailSubject: 'Verify your new account',
+        SmsMessage: 'The verification code to your new account is {####}',
+      },
+    })
+  );
 });

--- a/test/my-todo-list.test.ts
+++ b/test/my-todo-list.test.ts
@@ -1,13 +1,39 @@
-// import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
-// import * as cdk from '@aws-cdk/core';
-// import * as MyTodoList from '../lib/my-todo-list-stack';
+import {
+  expect as expectCDK,
+  countResources,
+  haveResource,
+} from '@aws-cdk/assert';
+import * as cdk from '@aws-cdk/core';
+import * as todoApi from '../lib/my-todo-list-stack';
+import { ResourceName } from '../lib/resourceName';
 
-// test('Empty Stack', () => {
-//     const app = new cdk.App();
-//     // WHEN
-//     const stack = new MyTodoList.MyTodoListStack(app, 'MyTestStack');
-//     // THEN
-//     expectCDK(stack).to(matchTemplate({
-//       "Resources": {}
-//     }, MatchStyle.EXACT))
-// });
+const systemEnv = process.env.SYSTEM_ENV ? process.env.SYSTEM_ENV : 'dev';
+const resourceName = new ResourceName('todo', systemEnv);
+
+const app = new cdk.App();
+const stack = new todoApi.MyTodoListStack(app, resourceName, {
+  callbackUrls: ['http://localhost:3200/oauth2-redirect.html'],
+  logoutUrls: ['http://localhost:3200/oauth2-redirect.html'],
+  frontendUrls: ['http://localhost:3200'],
+  domainPrefix: process.env.DOMAIN_PREFIX!,
+});
+
+test('API Gateway', () => {
+  expectCDK(stack).to(countResources('AWS::ApiGatewayV2::Api', 1));
+});
+
+test('Lambda', () => {
+  expectCDK(stack).to(countResources('AWS::Lambda::Function', 1));
+});
+
+test('IAM Role', () => {
+  expectCDK(stack).to(countResources('AWS::IAM::Role', 1));
+});
+
+test('DynamoDB', () => {
+  expectCDK(stack).to(countResources('AWS::DynamoDB::Table', 1));
+});
+
+test('Cognito UserPool', () => {
+  expectCDK(stack).to(countResources('AWS::Cognito::UserPool', 1));
+});


### PR DESCRIPTION
## チケットへのリンク

* close #32

## やったこと

* インフラパラメータの見直し
    * DynamoDBの支払いタイプをオンデマンドモードへ
    *  Cognito削除時の挙動をsnapshotへ
* インフラのテストの追加
    * リソース数が多かったので、CDKで明示的に作成しているリソースについてのみテストコードを実装
       * 依存関係的に作られるリソースはテストコードを実装していない
    * リソース数とプロパティをテスト 

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] ローカルテストが通ることを確認
* [x] デプロイが可能なことを確認 

## その他

* なし