### PR TITLE
複数環境対応（Swagger, Actions）

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,18 +18,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Check Release Branch
-        if: ${{ github.ref == 'refs/heads/release' }}
+      - name: Check release branch
+        if: ${{ github.base_ref == 'release' }}
         run: echo "SYSTEM_ENV=prd" >> $GITHUB_ENV
 
-      - name: Check Main Branch
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Check main branch
+        if: ${{ github.base_ref == 'main' }}
         run: echo "SYSTEM_ENV=stg" >> $GITHUB_ENV
 
       - name: Setup environment variables
         run: |
-          echo DOMAIN_PREFIX=${{'my-todo-'}}${{env.SYSTEM_ENV}} >> $GITHUB_ENV
-          echo TABLE_NAME=${{'MyTodoList-'}}${{env.SYSTEM_ENV}}${{'-todo-table'}} >> $GITHUB_ENV
+          echo AMPLIFY_URL=${{secrets.AMPLIFY_URL}} >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,3 +6,5 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest'
   }
 };
+
+process.env = Object.assign(process.env, { TABLE_NAME: 'MyTodoList-dev-todo-table' });

--- a/src/infrastructures/dynamodb/tasks-table.ts
+++ b/src/infrastructures/dynamodb/tasks-table.ts
@@ -2,10 +2,12 @@ import * as ddbLib from '@aws-sdk/lib-dynamodb';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Task, TaskSummary, UpdateTaskInfo } from '../../utils/types';
 
-const tableName: string | undefined = process.env.TABLE_NAME;
-if (!tableName) {
+// テーブル名のチェック
+if (!process.env.TABLE_NAME) {
   throw new Error('テーブル名を取得できませんでした。');
 }
+const tableName = process.env.TABLE_NAME!;
+
 export const ddbClient = new DynamoDBClient({ region: 'ap-northeast-1' });
 export const ddbDocClient = ddbLib.DynamoDBDocumentClient.from(ddbClient);
 

--- a/test/infrastructures/dynamodb/tasks-table.test.ts
+++ b/test/infrastructures/dynamodb/tasks-table.test.ts
@@ -4,7 +4,7 @@ import * as infra from '../../../src/infrastructures/dynamodb/tasks-table';
 import { v4 as uuidv4 } from 'uuid';
 import { Task, TaskSummary } from '../../../src/utils/types';
 
-const tableName = process.env.TABLE_NAME;
+const tableName = 'MyTodoList-dev-todo-table';
 const ddbMock = mockClient(infra.ddbDocClient);
 
 /**

--- a/test/my-todo-list.test.ts
+++ b/test/my-todo-list.test.ts
@@ -15,7 +15,7 @@ const stack = new todoApi.MyTodoListStack(app, resourceName, {
   callbackUrls: ['http://localhost:3200/oauth2-redirect.html'],
   logoutUrls: ['http://localhost:3200/oauth2-redirect.html'],
   frontendUrls: ['http://localhost:3200'],
-  domainPrefix: process.env.DOMAIN_PREFIX!,
+  domainPrefix: 'my-todo-dev',
 });
 
 test('API Gateway', () => {


### PR DESCRIPTION
## チケットへのリンク

*  #44 
    * **closeはしない**

## やったこと

* CORS設定のための`props`を環境ごとに出し分けるように変更
    * `stg`, `prd`はAmplifyからのみ
    * `dev`はローカルホストも許可
* これに関連したActionsのワークフローとテストの見直し  

## やらないこと

* 別途PRを作成して確認
    * [ ] releaseブランチでの動作確認
    * [ ] Swaggerからの動作確認

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* [x] Actionsが動作すること（本PRではテストと`cdk diff`まで）
* [ ] 本PRのマージ後に`cdk deploy`が動いていること

## その他

* なし