### PR TITLE
Amplify上のSwaggerからはステージング環境を参照するように変更

### DIFF
--- a/bin/my-todo-list.ts
+++ b/bin/my-todo-list.ts
@@ -16,7 +16,7 @@ const app = new cdk.App();
 // 環境名ごとにpropsの内容を変更
 const amplifyUrl = process.env.AMPLIFY_URL ? process.env.AMPLIFY_URL : '';
 const frontendUrls = [amplifyUrl];
-if (systemEnv === 'dev') {
+if (systemEnv === 'dev' || systemEnv === 'stg') {
   frontendUrls.push('http://localhost:3200');
 }
 const callbackAndLogoutUrls = frontendUrls.map(

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,15 +1,15 @@
 openapi: 3.0.3
 info:
   title: TODO API overview
-  description: TODOリストを管理するAPI
+  description: TODOリストを管理するAPIです。認証時にはclient_idに「3ek5rhfdm36n6f6sqeierekufa」を入力してください。
   version: 1.0.0
 servers:
-  - url: "https://84jjepso4j.execute-api.ap-northeast-1.amazonaws.com/"
-    description: "開発環境"
   - url: "https://a97l74fmi7.execute-api.ap-northeast-1.amazonaws.com/"
     description: "ステージング環境"
-  - url: "https://nff5i7zpo9.execute-api.ap-northeast-1.amazonaws.com/"
-    description: "本番環境"
+  # - url: "https://84jjepso4j.execute-api.ap-northeast-1.amazonaws.com/"
+  #   description: "開発環境"
+  # - url: "https://nff5i7zpo9.execute-api.ap-northeast-1.amazonaws.com/"
+  #   description: "本番環境"
 components:
   securitySchemes:
     OAuth2:
@@ -17,10 +17,19 @@ components:
       description: "For more information, see https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-userpools-server-contract-reference.html"
       flows:
         authorizationCode:
-          authorizationUrl: "https://my-todo-dev.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"
-          tokenUrl: "https://my-todo-dev.auth.ap-northeast-1.amazoncognito.com/oauth2/token"
+          authorizationUrl: "https://my-todo-stg.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"
+          tokenUrl: "https://my-todo-stg.auth.ap-northeast-1.amazoncognito.com/oauth2/token"
           scopes:
             openid: openid token
+    # OAuth2:
+    #   type: oauth2
+    #   description: "For more information, see https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-userpools-server-contract-reference.html"
+    #   flows:
+    #     authorizationCode:
+    #       authorizationUrl: "https://my-todo-dev.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"
+    #       tokenUrl: "https://my-todo-dev.auth.ap-northeast-1.amazoncognito.com/oauth2/token"
+    #       scopes:
+    #         openid: openid token
   schemas:
     Task:
       description: ""


### PR DESCRIPTION
## チケットへのリンク

* #45 
* #49

## やったこと

* Amplify上のSwaggerからはステージング環境を参照するように変更
    * **Swaggerの認証は1環境分しか設定できない**

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* ローカルのSwaggerから表示への反映を確認

## その他

* なし